### PR TITLE
added support for processing multiple lists

### DIFF
--- a/src/PmapProgressMeter.jl
+++ b/src/PmapProgressMeter.jl
@@ -7,7 +7,7 @@ globalProgressMeters = Dict()
 globalProgressValues = Dict()
 
 "Wraps pmap with a progress meter."
-function Base.pmap(f::Function, p::Progress, values; kwargs...)
+function Base.pmap(f::Function, p::Progress, values...; kwargs...)
     global globalProgressMeters
     global globalProgressValues
 
@@ -15,12 +15,11 @@ function Base.pmap(f::Function, p::Progress, values; kwargs...)
     globalProgressMeters[id] = p
     globalProgressValues[id] = 0
 
-    function mapper(x)
-        v = f(x)
+    out = pmap(values...; kwargs...) do x...
+        v = f(x...)
         wait(remotecall(1, updateProgressMeter, id))
         v
     end
-    out = pmap(mapper, values; kwargs...)
 
     delete!(globalProgressMeters, id)
     out

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,8 @@ end
 vals = 1:10
 p = Progress(length(vals))
 @test pmap(x->begin sleep(.1); x*2 end, p, vals, err_stop=true)[1] == vals[1]*2
+
+# try with multiple lists
+vals2 = 10:-1:1
+p = Progress(length(vals))
+@test pmap(+, p, vals, vals2) == 11*ones(Int,length(vals))


### PR DESCRIPTION
pmap supports processing multiple argument lists, e.g. `pmap(+,1:10,1:10)`. This PR adds support for this to the progress meter version.

Note: I had to switch to the `do` syntax rather than defining `mapper` because it would not work with the function named `mapper`. I suspect this has something to do with `mapper` not being defined on all processes, but I'm not sure.
