### PR TITLE
added reentrant lock for printing to prevent misprints

### DIFF
--- a/src/PmapProgressMeter.jl
+++ b/src/PmapProgressMeter.jl
@@ -5,15 +5,18 @@ using ProgressMeter
 # a global to hold progress meter references
 globalProgressMeters = Dict()
 globalProgressValues = Dict()
+globalPrintLock = Dict()
 
 "Wraps pmap with a progress meter."
 function Base.pmap(f::Function, p::Progress, values...; kwargs...)
     global globalProgressMeters
     global globalProgressValues
+    global globalPrintLock
 
     id = randstring(50)
     globalProgressMeters[id] = p
     globalProgressValues[id] = 0
+    globalPrintLock[id] = ReentrantLock()
 
     out = pmap(values...; kwargs...) do x...
         v = f(x...)
@@ -29,9 +32,12 @@ end
 function updateProgressMeter(id)
     global globalProgressMeters
     global globalProgressValues
+    global globalIsPrinting
 
+    lock(globalPrintLock[id])
     globalProgressValues[id] += 1
     update!(globalProgressMeters[id] , globalProgressValues[id])
+    unlock(globalPrintLock[id])
 end
 
 end # module

--- a/src/PmapProgressMeter.jl
+++ b/src/PmapProgressMeter.jl
@@ -32,7 +32,7 @@ end
 function updateProgressMeter(id)
     global globalProgressMeters
     global globalProgressValues
-    global globalIsPrinting
+    global globalPrintLock
 
     lock(globalPrintLock[id])
     globalProgressValues[id] += 1


### PR DESCRIPTION
Before this, the printing would often be messy (i.e. it would try to print two progress meters on the same line) if a bunch of calls to updateProgressMeter were made quickly. adding a reentrant lock fixes this.
