### PR TITLE
Allow continuing existing progress

### DIFF
--- a/src/PmapProgressMeter.jl
+++ b/src/PmapProgressMeter.jl
@@ -17,7 +17,7 @@ function Base.pmap(f::Function, p::Progress, values...; kwargs...)
 
     id = randstring(50)
     globalProgressMeters[id] = p
-    globalProgressValues[id] = 0
+    globalProgressValues[id] = p.counter
     globalPrintLock[id] = ReentrantLock()
 
     passcallback = false


### PR DESCRIPTION
Instead of initializing with value 0, use counter state of Progress object to allow continuing partial progress.